### PR TITLE
Unit test explode - part 1

### DIFF
--- a/src/main.aspec.js
+++ b/src/main.aspec.js
@@ -11,61 +11,64 @@ if (typeof msngr === "undefined" && typeof window === "undefined") {
 }
 
 describe("./main.js", function () {
-    it("msngr", function () {
-        // Ensure msngr exists in the first place
-        expect(msngr).to.not.equal(undefined);
+    "use strict";
+
+    it("msngr - expect object to exist", function () {
+        expect(msngr).to.exist;
     });
 
-    it("msngr.extend()", function () {
-        // Check that extend exists
-        expect(msngr.extend).to.not.equal(undefined);
-        // Ensure that the method we're adding doesn't exist
-        expect(msngr.test_extend).to.equal(undefined);
-        // Extend msngr with new method
-        msngr.extend({
-            test_extend: function () {
+    it("msngr.extend(obj, target) - expect method to exist", function () {
+        expect(msngr.extend).to.exist;
+    });
 
-            }
-        });
-        // Ensure new method now exists
-        expect(msngr.test_extend).to.not.equal(undefined);
-        // Drop new method
-        delete msngr.test_extend;
-        // Ensure new method is gone again
-        expect(msngr.test_extend).to.equal(undefined);
+    it("msngr.extend(obj, target) - merges arrays from obj and target", function () {
+        var obj1 = { test: [1, 2] };
+        var obj2 = { test: [3, 4] };
 
-        // Complex extend
-        msngr.extend({
-            test_extend: {
-                test: "test"
-            }
-        });
-        msngr.extend({
-            test_extend: {
-                another: "test"
-            }
-        });
-        expect(msngr.test_extend.test).to.equal(msngr.test_extend.another);
-        expect(msngr.test_extend.test).to.not.equal(msngr.test);
-        // Drop new methods again
-        delete msngr.test_extend;
+        msngr.extend(obj1, obj2);
 
-        // Check mixin support with arrays; no modifying of base msngr object.
-        var obj = msngr.extend({
-            testing: {
-                tests: ["test", "again"]
-            },
-            another: ["yup", "yip", "yop"]
-        }, {
-            testing: {
-                test: "yes",
-                tests: ["another", "weee"]
+        expect(obj2.test).to.exist;
+        expect(obj2.test.length).to.equal(4);
+    });
+
+    it("msngr.extend(obj, target) - expect properties to merge from obj and target", function () {
+        var obj1 = { prop: "something" };
+        var obj2 = { some: "thing" };
+
+        msngr.extend(obj1, obj2);
+
+        expect(obj2.some).to.exist;
+        expect(obj2.prop).to.exist;
+        expect(obj2.prop).to.equal("something");
+    });
+
+    it("msngr.extend(obj, target) - expect deeply nested methods to merge from obj and target", function () {
+        var obj1 = {
+            this: {
+                is: {
+                    a: {
+                        test: {
+                            yup: function () { return "yup!"; }
+                        }
+                    }
+                }
             }
-        });
-        expect(obj.testing.tests.length > 0).to.equal(true);
-        expect(obj.testing.tests.length === 4).to.equal(true);
-        expect(obj.another.length > 0).to.equal(true);
-        expect(msngr.utils.getType(obj.testing.tests)).to.equal("[object Array]");
-        expect(msngr.utils.getType(obj.another)).to.equal("[object Array]");
+        };
+
+        var obj2 = {
+            whatever: function () { return "whatever"; }
+        };
+
+        msngr.extend(obj1, obj2);
+
+        expect(obj2.whatever).to.exist;
+        expect(obj2.whatever()).to.equal("whatever");
+
+        expect(obj2.this).to.exist;
+        expect(obj2.this.is).to.exist;
+        expect(obj2.this.is.a).to.exist;
+        expect(obj2.this.is.a.test).to.exist;
+        expect(obj2.this.is.a.test.yup).to.exist;
+        expect(obj2.this.is.a.test.yup()).to.equal("yup!");
     });
 });

--- a/src/utils/converters.aspec.js
+++ b/src/utils/converters.aspec.js
@@ -13,24 +13,30 @@ if (typeof msngr === "undefined" && typeof window === "undefined") {
 describe("./utils/converters.js", function () {
     "use strict";
 
-    it("msngr.utils.argumentsToArray(args)", function () {
-        var func1 = function () {
-            var args = msngr.utils.argumentsToArray(arguments);
-            expect(args.length).to.equal(3);
-        }
-
-        var func2 = function () {
-            var args = msngr.utils.argumentsToArray(arguments);
-            expect(args.length).to.equal(1);
-        }
-
-        var func3 = function () {
+    it("msngr.utils.argumentsToArray(args) - 0 arguments", function () {
+        var func = function () {
             var args = msngr.utils.argumentsToArray(arguments);
             expect(args.length).to.equal(0);
         }
 
-        func1("whatever", "something", "weee");
-        func2("foobar");
-        func3();
+        func();
+    });
+
+    it("msngr.utils.argumentsToArray(args) - 3 arguments", function () {
+        var func = function () {
+            var args = msngr.utils.argumentsToArray(arguments);
+            expect(args.length).to.equal(3);
+        }
+
+        func(1, 2, 3);
+    });
+
+    it("msngr.utils.argumentsToArray(args) - 15 arguments", function () {
+        var func = function () {
+            var args = msngr.utils.argumentsToArray(arguments);
+            expect(args.length).to.equal(15);
+        }
+
+        func(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
     });
 });

--- a/src/utils/dom.cspec.js
+++ b/src/utils/dom.cspec.js
@@ -13,23 +13,65 @@ if (typeof msngr === "undefined" && typeof window === "undefined") {
 describe("./utils/dom.js", function () {
     "use strict";
 
-    it("msngr.utils.isHtmlElement(obj)", function () {
+    it("msngr.utils.isHtmlElement(obj) - obj is a function", function () {
         expect(msngr.utils.isHtmlElement(function () {})).to.equal(false);
+    });
+
+    it("msngr.utils.isHtmlElement(obj) - obj is a string", function () {
         expect(msngr.utils.isHtmlElement("test")).to.equal(false);
+    });
+
+    it("msngr.utils.isHtmlElement(obj) - obj is an empty string", function () {
         expect(msngr.utils.isHtmlElement("")).to.equal(false);
+    });
+
+    it("msngr.utils.isHtmlElement(obj) - obj is undefined", function () {
         expect(msngr.utils.isHtmlElement(undefined)).to.equal(false);
+    });
+
+    it("msngr.utils.isHtmlElement(obj) - obj is null", function () {
         expect(msngr.utils.isHtmlElement(null)).to.equal(false);
+    });
+
+    it("msngr.utils.isHtmlElement(obj) - obj is an object", function () {
         expect(msngr.utils.isHtmlElement({})).to.equal(false);
+    });
+
+    it("msngr.utils.isHtmlElement(obj) - obj is a number", function () {
         expect(msngr.utils.isHtmlElement(7)).to.equal(false);
+    });
+
+    it("msngr.utils.isHtmlElement(obj) - obj is an array", function () {
         expect(msngr.utils.isHtmlElement([])).to.equal(false);
+    });
+
+    it("msngr.utils.isHtmlElement(obj) - obj is a date", function () {
         expect(msngr.utils.isHtmlElement(new Date())).to.equal(false);
+    });
+
+    it("msngr.utils.isHtmlElement(obj) - obj is a div element", function () {
         expect(msngr.utils.isHtmlElement(document.createElement("div"))).to.equal(true);
+    });
+
+    it("msngr.utils.isHtmlElement(obj) - obj is an input element", function () {
         expect(msngr.utils.isHtmlElement(document.createElement("input"))).to.equal(true);
+    });
+
+    it("msngr.utils.isHtmlElement(obj) - obj is a body element", function () {
         expect(msngr.utils.isHtmlElement(document.createElement("body"))).to.equal(true);
+    });
+
+    it("msngr.utils.isHtmlElement(obj) - obj is a canvas element", function () {
         expect(msngr.utils.isHtmlElement(document.createElement("canvas"))).to.equal(true);
     });
 
-    it("msngr.utils.isNodeList(obj)", function () {
+    it("msngr.utils.isNodeList(obj) - obj is a single div element", function () {
+        var div = document.createElement("div");
+
+        expect(msngr.utils.isNodeList(div)).to.equal(false);
+    });
+
+    it("msngr.utils.isNodeList(obj) - obj is a nodelist", function () {
         var div1 = document.createElement("div");
         var div2 = document.createElement("div");
         var div3 = document.createElement("div");
@@ -37,39 +79,55 @@ describe("./utils/dom.js", function () {
         div1.appendChild(div2);
         div1.appendChild(div3);
 
-        expect(msngr.utils.isNodeList(div1)).to.equal(false);
         expect(msngr.utils.isNodeList(div1.childNodes)).to.equal(true);
     });
 
-    it("msngr.utils.findElement(obj)", function () {
-        var div = document.createElement("div");
-        div.style.display = "none";
-
-        var div2 = document.createElement("div");
-        div2.setAttribute("id", "TestID1");
-
-        var div3 = document.createElement("div");
-        div3.setAttribute("class", "TestClass1");
-
-        var p1 = document.createElement("p");
-        div3.appendChild(p1);
-
-        div.appendChild(div2);
-        div.appendChild(div3);
-
-        document.body.appendChild(div);
-
-        expect(msngr.utils.isHtmlElement(msngr.utils.findElement("#TestID1"))).to.equal(true);
-        expect(msngr.utils.isHtmlElement(msngr.utils.findElement("#TestI1"))).to.equal(false);
-        expect(msngr.utils.isHtmlElement(msngr.utils.findElement("TestID1"))).to.equal(true);
-        expect(msngr.utils.isHtmlElement(msngr.utils.findElement(".TestClass1"))).to.equal(true);
-        expect(msngr.utils.isHtmlElement(msngr.utils.findElement(".Testass1"))).to.equal(false);
-        expect(msngr.utils.isHtmlElement(msngr.utils.findElement("div div p"))).to.equal(true);
-        expect(msngr.utils.isHtmlElement(msngr.utils.findElement("p div"))).to.equal(false);
+    it("msngr.utils.findElement(obj) - obj is an HTMLElement", function () {
         expect(msngr.utils.isHtmlElement(msngr.utils.findElement(document.createElement("div")))).to.equal(true);
     });
 
-    it("msngr.utils.getDomPath(element)", function () {
+    it("msngr.utils.findElement(obj) - obj is an id (MyID)", function () {
+        var div = document.createElement("div");
+        div.setAttribute("id", "TestID1");
+        document.body.appendChild(div);
+        expect(msngr.utils.isHtmlElement(msngr.utils.findElement("TestID1"))).to.equal(true);
+        document.body.removeChild(div);
+        expect(msngr.utils.isHtmlElement(msngr.utils.findElement("TestID1"))).to.equal(false);
+    });
+
+    it("msngr.utils.findElement(obj) - obj is an id selector (#MyID)", function () {
+        var div = document.createElement("div");
+        div.setAttribute("id", "TestID1");
+        document.body.appendChild(div);
+        expect(msngr.utils.isHtmlElement(msngr.utils.findElement("#TestID1"))).to.equal(true);
+        document.body.removeChild(div);
+        expect(msngr.utils.isHtmlElement(msngr.utils.findElement("#TestID1"))).to.equal(false);
+    });
+
+    it("msngr.utils.findElement(obj) - obj is a class selector (.TestClass)", function () {
+        var div = document.createElement("div");
+        div.setAttribute("class", "TestClass");
+        document.body.appendChild(div);
+        expect(msngr.utils.isHtmlElement(msngr.utils.findElement(".TestClass"))).to.equal(true);
+        document.body.removeChild(div);
+        expect(msngr.utils.isHtmlElement(msngr.utils.findElement(".TestClass"))).to.equal(false);
+    });
+
+    it("msngr.utils.findElement(obj) - obj is a html target selector", function () {
+        var div = document.createElement("div");
+        var div2 = document.createElement("div");
+        var p = document.createElement("p");
+
+        div2.appendChild(p);
+        div.appendChild(div2);
+
+        document.body.appendChild(div);
+        expect(msngr.utils.isHtmlElement(msngr.utils.findElement("div div p"))).to.equal(true);
+        document.body.removeChild(div);
+        expect(msngr.utils.isHtmlElement(msngr.utils.findElement("div div p"))).to.equal(false);
+    });
+
+    it("msngr.utils.getDomPath(element) - element is a tested HTMLElement", function () {
         var div = document.createElement("div");
         div.style.display = "none";
 
@@ -81,9 +139,10 @@ describe("./utils/dom.js", function () {
         document.body.appendChild(div);
         var path = msngr.utils.getDomPath(msngr.utils.findElement("TestID2"));
         expect(msngr.utils.querySelectorAllWithEq(path)[0].id).to.equal("TestID2");
+        document.body.removeChild(div);
     });
 
-    it("msngr.utils.querySelectorAllWithEq(selector)", function () {
+    it("msngr.utils.querySelectorAllWithEq(selector) - selector uses eq to target specific indexes", function () {
         var div = document.createElement("div");
         div.style.display = "none";
 
@@ -113,7 +172,7 @@ describe("./utils/dom.js", function () {
 
     });
 
-    it("msngr.utils.querySelectorWithEq(selector)", function () {
+    it("msngr.utils.querySelectorWithEq(selector) - selector uses eq to target specific indexes", function () {
         var div = document.createElement("div");
         div.style.display = "none";
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,6 +1,6 @@
 msngr.extend((function () {
     "use strict";
-    
+
     return {
         utils: {
             isHtmlElement: function (obj) {

--- a/src/utils/misc.aspec.js
+++ b/src/utils/misc.aspec.js
@@ -15,9 +15,23 @@ describe("./utils/misc.js", function () {
 
     this.timeout(60000);
 
-    it("msngr.utils.id()", function () {
+    it("msngr.utils.id() - generate 1 id", function () {
         expect(msngr.utils.id()).to.not.equal(undefined);
+    });
 
+    it("msngr.utils.id() - generate 100 unique ids", function () {
+        var ids = [];
+        for (var i = 0; i < 100; ++i) {
+            var d = msngr.utils.id();
+            if (ids.indexOf(d) === -1) {
+                ids.push(d);
+            }
+        }
+
+        expect(ids.length).to.equal(100);
+    });
+
+    it("msngr.utils.id() - generate 10000 unique ids", function () {
         var ids = [];
         for (var i = 0; i < 10000; ++i) {
             var d = msngr.utils.id();
@@ -29,7 +43,11 @@ describe("./utils/misc.js", function () {
         expect(ids.length).to.equal(10000);
     });
 
-    it("msngr.utils.now()", function () {
+    it("msngr.utils.now() - generates a value", function () {
+        expect(msngr.utils.now()).to.exist;
+    });
+
+    it("msngr.utils.now(true) - 5 consecutive calls have unique values", function () {
         var t1 = msngr.utils.now(true);
         var t2 = msngr.utils.now(true);
         var t3 = msngr.utils.now(true);

--- a/src/utils/validation.aspec.js
+++ b/src/utils/validation.aspec.js
@@ -13,119 +13,364 @@ if (typeof msngr === "undefined" && typeof window === "undefined") {
 describe("./utils/validation.js", function () {
     "use strict";
 
-    it("msngr.utils.isNullOrUndefined(obj)", function () {
-        expect(msngr.utils.isNullOrUndefined("test")).to.equal(false);
-        expect(msngr.utils.isNullOrUndefined("")).to.equal(false);
-        expect(msngr.utils.isNullOrUndefined(undefined)).to.equal(true);
-        expect(msngr.utils.isNullOrUndefined(null)).to.equal(true);
-        expect(msngr.utils.isNullOrUndefined({})).to.equal(false);
-        expect(msngr.utils.isNullOrUndefined(7)).to.equal(false);
-        expect(msngr.utils.isNullOrUndefined([])).to.equal(false);
-        expect(msngr.utils.isNullOrUndefined(new Date())).to.equal(false);
-        expect(msngr.utils.isNullOrUndefined(function () {})).to.equal(false);
-    });
-
-    it("msngr.utils.exists(obj)", function () {
-        expect(msngr.utils.exists(undefined)).to.equal(false);
-        expect(msngr.utils.exists(null)).to.equal(false);
-        expect(msngr.utils.exists("")).to.equal(true);
-        expect(msngr.utils.exists(7)).to.equal(true);
-        expect(msngr.utils.exists({})).to.equal(true);
-        expect(msngr.utils.exists([])).to.equal(true);
-        expect(msngr.utils.exists(new Date())).to.equal(true);
-        expect(msngr.utils.exists(function () {})).to.equal(true);
-    });
-
-    it("msngr.utils.isString(obj)", function () {
-        expect(msngr.utils.isString("test")).to.equal(true);
-        expect(msngr.utils.isString("")).to.equal(true);
-        expect(msngr.utils.isString(undefined)).to.equal(false);
-        expect(msngr.utils.isString(null)).to.equal(false);
-        expect(msngr.utils.isString({})).to.equal(false);
-        expect(msngr.utils.isString(7)).to.equal(false);
-        expect(msngr.utils.isString([])).to.equal(false);
-        expect(msngr.utils.isString(new Date())).to.equal(false);
-        expect(msngr.utils.isString(function () {})).to.equal(false);
-    });
-
-    it("msngr.utils.isObject(obj)", function () {
-        expect(msngr.utils.isObject("test")).to.equal(false);
-        expect(msngr.utils.isObject("")).to.equal(false);
-        expect(msngr.utils.isObject(undefined)).to.equal(false);
-        expect(msngr.utils.isObject(null)).to.equal(false);
-        expect(msngr.utils.isObject({})).to.equal(true);
-        expect(msngr.utils.isObject(7)).to.equal(false);
-        expect(msngr.utils.isObject([])).to.equal(false);
-        expect(msngr.utils.isObject(new Date())).to.equal(false);
-        expect(msngr.utils.isObject(function () {})).to.equal(false);
-    });
-
-    it("msngr.utils.isNumber(obj)", function () {
-        expect(msngr.utils.isNumber("test")).to.equal(false);
-        expect(msngr.utils.isNumber("")).to.equal(false);
-        expect(msngr.utils.isNumber(undefined)).to.equal(false);
-        expect(msngr.utils.isNumber(null)).to.equal(false);
-        expect(msngr.utils.isNumber({})).to.equal(false);
-        expect(msngr.utils.isNumber(7)).to.equal(true);
-        expect(msngr.utils.isNumber([])).to.equal(false);
-        expect(msngr.utils.isNumber(new Date())).to.equal(false);
-        expect(msngr.utils.isNumber(function () {})).to.equal(false);
-    });
-
-    it("msngr.utils.isDate(obj)", function () {
-        expect(msngr.utils.isDate("test")).to.equal(false);
-        expect(msngr.utils.isDate("")).to.equal(false);
-        expect(msngr.utils.isDate(undefined)).to.equal(false);
-        expect(msngr.utils.isDate(null)).to.equal(false);
-        expect(msngr.utils.isDate({})).to.equal(false);
-        expect(msngr.utils.isDate(7)).to.equal(false);
-        expect(msngr.utils.isDate([])).to.equal(false);
-        expect(msngr.utils.isDate(new Date())).to.equal(true);
-        expect(msngr.utils.isDate(function () {})).to.equal(false);
-    });
-
-    it("msngr.utils.isFunction(obj)", function () {
-        expect(msngr.utils.isFunction(function () {})).to.equal(true);
-        expect(msngr.utils.isFunction("test")).to.equal(false);
-        expect(msngr.utils.isFunction("")).to.equal(false);
-        expect(msngr.utils.isFunction(undefined)).to.equal(false);
-        expect(msngr.utils.isFunction(null)).to.equal(false);
-        expect(msngr.utils.isFunction({})).to.equal(false);
-        expect(msngr.utils.isFunction(7)).to.equal(false);
-        expect(msngr.utils.isFunction([])).to.equal(false);
-        expect(msngr.utils.isFunction(new Date())).to.equal(false);
-    });
-
-    it("msngr.utils.isArray(obj)", function () {
-        expect(msngr.utils.isArray(function () {})).to.equal(false);
-        expect(msngr.utils.isArray("test")).to.equal(false);
-        expect(msngr.utils.isArray("")).to.equal(false);
-        expect(msngr.utils.isArray(undefined)).to.equal(false);
-        expect(msngr.utils.isArray(null)).to.equal(false);
-        expect(msngr.utils.isArray({})).to.equal(false);
-        expect(msngr.utils.isArray(7)).to.equal(false);
-        expect(msngr.utils.isArray(new Date())).to.equal(false);
-        expect(msngr.utils.isArray(new Array)).to.equal(true);
-        expect(msngr.utils.isArray([])).to.equal(true);
-        expect(msngr.utils.isArray([1,2,3,4,5])).to.equal(true);
-    });
-
-    it("msngr.utils.getType(obj)", function () {
+    it("msngr.utils.getType(obj) - obj is a function", function () {
         expect(msngr.utils.getType(function () {})).to.equal("[object Function]");
+    });
+
+    it("msngr.utils.getType(obj) - obj is a string", function () {
         expect(msngr.utils.getType("test")).to.equal("[object String]");
     });
 
-    it("msngr.utils.isEmptyString(str)", function () {
+    it("msngr.utils.getType(obj) - obj is a number", function () {
+        expect(msngr.utils.getType(42)).to.equal("[object Number]");
+    });
+
+    it("msngr.utils.getType(obj) - obj is an array", function () {
+        expect(msngr.utils.getType([])).to.equal("[object Array]");
+    });
+
+    it("msngr.utils.getType(obj) - obj is an object", function () {
+        expect(msngr.utils.getType({ })).to.equal("[object Object]");
+    });
+
+    it("msngr.utils.getType(obj) - obj is undefined", function () {
+        expect(msngr.utils.getType(undefined)).to.equal("undefined");
+    });
+
+    it("msngr.utils.getType(obj) - obj is null", function () {
+        expect(msngr.utils.getType(null)).to.equal("null");
+    });
+
+    // isNullOrUndefined(obj)
+    it("msngr.utils.isNullOrUndefined(obj) - obj is a function", function () {
+        expect(msngr.utils.isNullOrUndefined(function () {})).to.equal(false);
+    });
+
+    it("msngr.utils.isNullOrUndefined(obj) - obj is a string with content", function () {
+        expect(msngr.utils.isNullOrUndefined("test")).to.equal(false);
+    });
+
+    it("msngr.utils.isNullOrUndefined(obj) - obj is an empty string", function () {
+        expect(msngr.utils.isNullOrUndefined("")).to.equal(false);
+    });
+
+    it("msngr.utils.isNullOrUndefined(obj) - obj is a string with only whitespace", function () {
+        expect(msngr.utils.isNullOrUndefined(" ")).to.equal(false);
+    });
+
+    it("msngr.utils.isNullOrUndefined(obj) - obj is undefined", function () {
+        expect(msngr.utils.isNullOrUndefined(undefined)).to.equal(true);
+    });
+
+    it("msngr.utils.isNullOrUndefined(obj) - obj is null", function () {
+        expect(msngr.utils.isNullOrUndefined(null)).to.equal(true);
+    });
+
+    it("msngr.utils.isNullOrUndefined(obj) - obj is an object", function () {
+        expect(msngr.utils.isNullOrUndefined({})).to.equal(false);
+    });
+
+    it("msngr.utils.isNullOrUndefined(obj) - obj is a number", function () {
+        expect(msngr.utils.isNullOrUndefined(7)).to.equal(false);
+    });
+
+    it("msngr.utils.isNullOrUndefined(obj) - obj is an array", function () {
+        expect(msngr.utils.isNullOrUndefined([])).to.equal(false);
+    });
+
+    it("msngr.utils.isNullOrUndefined(obj) - obj is a Date", function () {
+        expect(msngr.utils.isNullOrUndefined(new Date())).to.equal(false);
+    });
+
+    // isString(str)
+    it("msngr.utils.isString(str) - obj is a function", function () {
+        expect(msngr.utils.isString(function () {})).to.equal(false);
+    });
+
+    it("msngr.utils.isString(str) - obj is a string with content", function () {
+        expect(msngr.utils.isString("test")).to.equal(true);
+    });
+
+    it("msngr.utils.isString(str) - obj is an empty string", function () {
+        expect(msngr.utils.isString("")).to.equal(true);
+    });
+
+    it("msngr.utils.isString(str) - obj is a string with only whitespace", function () {
+        expect(msngr.utils.isString(" ")).to.equal(true);
+    });
+
+    it("msngr.utils.isString(str) - obj is undefined", function () {
+        expect(msngr.utils.isString(undefined)).to.equal(false);
+    });
+
+    it("msngr.utils.isString(str) - obj is null", function () {
+        expect(msngr.utils.isString(null)).to.equal(false);
+    });
+
+    it("msngr.utils.isString(str) - obj is an object", function () {
+        expect(msngr.utils.isString({})).to.equal(false);
+    });
+
+    it("msngr.utils.isString(str) - obj is a number", function () {
+        expect(msngr.utils.isString(7)).to.equal(false);
+    });
+
+    it("msngr.utils.isString(str) - obj is an array", function () {
+        expect(msngr.utils.isString([])).to.equal(false);
+    });
+
+    it("msngr.utils.isString(str) - obj is a Date", function () {
+        expect(msngr.utils.isString(new Date())).to.equal(false);
+    });
+
+    // isDate(obj)
+    it("msngr.utils.isDate(obj) - obj is a function", function () {
+        expect(msngr.utils.isDate(function () {})).to.equal(false);
+    });
+
+    it("msngr.utils.isDate(obj) - obj is a string with content", function () {
+        expect(msngr.utils.isDate("test")).to.equal(false);
+    });
+
+    it("msngr.utils.isDate(obj) - obj is an empty string", function () {
+        expect(msngr.utils.isDate("")).to.equal(false);
+    });
+
+    it("msngr.utils.isDate(obj) - obj is a string with only whitespace", function () {
+        expect(msngr.utils.isDate(" ")).to.equal(false);
+    });
+
+    it("msngr.utils.isDate(obj) - obj is undefined", function () {
+        expect(msngr.utils.isDate(undefined)).to.equal(false);
+    });
+
+    it("msngr.utils.isDate(obj) - obj is null", function () {
+        expect(msngr.utils.isDate(null)).to.equal(false);
+    });
+
+    it("msngr.utils.isDate(obj) - obj is an object", function () {
+        expect(msngr.utils.isDate({})).to.equal(false);
+    });
+
+    it("msngr.utils.isDate(obj) - obj is a number", function () {
+        expect(msngr.utils.isDate(7)).to.equal(false);
+    });
+
+    it("msngr.utils.isDate(obj) - obj is an array", function () {
+        expect(msngr.utils.isDate([])).to.equal(false);
+    });
+
+    it("msngr.utils.isDate(obj) - obj is a Date", function () {
+        expect(msngr.utils.isDate(new Date())).to.equal(true);
+    });
+
+    // isArray(obj)
+    it("msngr.utils.isArray(obj) - obj is a function", function () {
+        expect(msngr.utils.isArray(function () {})).to.equal(false);
+    });
+
+    it("msngr.utils.isArray(obj) - obj is a string with content", function () {
+        expect(msngr.utils.isArray("test")).to.equal(false);
+    });
+
+    it("msngr.utils.isArray(obj) - obj is an empty string", function () {
+        expect(msngr.utils.isArray("")).to.equal(false);
+    });
+
+    it("msngr.utils.isArray(obj) - obj is a string with only whitespace", function () {
+        expect(msngr.utils.isArray(" ")).to.equal(false);
+    });
+
+    it("msngr.utils.isArray(obj) - obj is undefined", function () {
+        expect(msngr.utils.isArray(undefined)).to.equal(false);
+    });
+
+    it("msngr.utils.isArray(obj) - obj is null", function () {
+        expect(msngr.utils.isArray(null)).to.equal(false);
+    });
+
+    it("msngr.utils.isArray(obj) - obj is an object", function () {
+        expect(msngr.utils.isArray({})).to.equal(false);
+    });
+
+    it("msngr.utils.isArray(obj) - obj is a number", function () {
+        expect(msngr.utils.isArray(7)).to.equal(false);
+    });
+
+    it("msngr.utils.isArray(obj) - obj is an array", function () {
+        expect(msngr.utils.isArray([])).to.equal(true);
+    });
+
+    it("msngr.utils.isArray(obj) - obj is a Date", function () {
+        expect(msngr.utils.isArray(new Date())).to.equal(false);
+    });
+
+    // isNumber(obj)
+    it("msngr.utils.isNumber(obj) - obj is a function", function () {
+        expect(msngr.utils.isNumber(function () {})).to.equal(false);
+    });
+
+    it("msngr.utils.isNumber(obj) - obj is a string with content", function () {
+        expect(msngr.utils.isNumber("test")).to.equal(false);
+    });
+
+    it("msngr.utils.isNumber(obj) - obj is an empty string", function () {
+        expect(msngr.utils.isNumber("")).to.equal(false);
+    });
+
+    it("msngr.utils.isNumber(obj) - obj is a string with only whitespace", function () {
+        expect(msngr.utils.isNumber(" ")).to.equal(false);
+    });
+
+    it("msngr.utils.isNumber(obj) - obj is undefined", function () {
+        expect(msngr.utils.isNumber(undefined)).to.equal(false);
+    });
+
+    it("msngr.utils.isNumber(obj) - obj is null", function () {
+        expect(msngr.utils.isNumber(null)).to.equal(false);
+    });
+
+    it("msngr.utils.isNumber(obj) - obj is an object", function () {
+        expect(msngr.utils.isNumber({})).to.equal(false);
+    });
+
+    it("msngr.utils.isNumber(obj) - obj is a number", function () {
+        expect(msngr.utils.isNumber(7)).to.equal(true);
+    });
+
+    it("msngr.utils.isNumber(obj) - obj is an array", function () {
+        expect(msngr.utils.isNumber([])).to.equal(false);
+    });
+
+    it("msngr.utils.isNumber(obj) - obj is a Date", function () {
+        expect(msngr.utils.isNumber(new Date())).to.equal(false);
+    });
+
+    // isObject(obj)
+    it("msngr.utils.isObject(obj) - obj is a function", function () {
+        expect(msngr.utils.isObject(function () {})).to.equal(false);
+    });
+
+    it("msngr.utils.isObject(obj) - obj is a string with content", function () {
+        expect(msngr.utils.isObject("test")).to.equal(false);
+    });
+
+    it("msngr.utils.isObject(obj) - obj is an empty string", function () {
+        expect(msngr.utils.isObject("")).to.equal(false);
+    });
+
+    it("msngr.utils.isObject(obj) - obj is a string with only whitespace", function () {
+        expect(msngr.utils.isObject(" ")).to.equal(false);
+    });
+
+    it("msngr.utils.isObject(obj) - obj is undefined", function () {
+        expect(msngr.utils.isObject(undefined)).to.equal(false);
+    });
+
+    it("msngr.utils.isObject(obj) - obj is null", function () {
+        expect(msngr.utils.isObject(null)).to.equal(false);
+    });
+
+    it("msngr.utils.isObject(obj) - obj is an object", function () {
+        expect(msngr.utils.isObject({})).to.equal(true);
+    });
+
+    it("msngr.utils.isObject(obj) - obj is a number", function () {
+        expect(msngr.utils.isObject(7)).to.equal(false);
+    });
+
+    it("msngr.utils.isObject(obj) - obj is an array", function () {
+        expect(msngr.utils.isObject([])).to.equal(false);
+    });
+
+    it("msngr.utils.isObject(obj) - obj is a Date", function () {
+        expect(msngr.utils.isObject(new Date())).to.equal(false);
+    });
+
+    // isFunction(func)
+    it("msngr.utils.isFunction(func) - obj is a function", function () {
+        expect(msngr.utils.isFunction(function () {})).to.equal(true);
+    });
+
+    it("msngr.utils.isFunction(func) - obj is a string with content", function () {
+        expect(msngr.utils.isFunction("test")).to.equal(false);
+    });
+
+    it("msngr.utils.isFunction(func) - obj is an empty string", function () {
+        expect(msngr.utils.isFunction("")).to.equal(false);
+    });
+
+    it("msngr.utils.isFunction(func) - obj is a string with only whitespace", function () {
+        expect(msngr.utils.isFunction(" ")).to.equal(false);
+    });
+
+    it("msngr.utils.isFunction(func) - obj is undefined", function () {
+        expect(msngr.utils.isFunction(undefined)).to.equal(false);
+    });
+
+    it("msngr.utils.isFunction(func) - obj is null", function () {
+        expect(msngr.utils.isFunction(null)).to.equal(false);
+    });
+
+    it("msngr.utils.isFunction(func) - obj is an object", function () {
+        expect(msngr.utils.isFunction({})).to.equal(false);
+    });
+
+    it("msngr.utils.isFunction(func) - obj is a number", function () {
+        expect(msngr.utils.isFunction(7)).to.equal(false);
+    });
+
+    it("msngr.utils.isFunction(func) - obj is an array", function () {
+        expect(msngr.utils.isFunction([])).to.equal(false);
+    });
+
+    it("msngr.utils.isFunction(func) - obj is a Date", function () {
+        expect(msngr.utils.isFunction(new Date())).to.equal(false);
+    });
+
+    // isEmptyString(str)
+
+    it("msngr.utils.isEmptyString(str) - str is a function", function () {
         expect(msngr.utils.isEmptyString(function () {})).to.equal(false);
+    });
+
+    it("msngr.utils.isEmptyString(str) - str is a string with content", function () {
         expect(msngr.utils.isEmptyString("test")).to.equal(false);
+    });
+
+    it("msngr.utils.isEmptyString(str) - str is an empty string", function () {
         expect(msngr.utils.isEmptyString("")).to.equal(true);
+    });
+
+    it("msngr.utils.isEmptyString(str) - str is a string with only whitespace", function () {
+        expect(msngr.utils.isEmptyString(" ")).to.equal(true);
+    });
+
+    it("msngr.utils.isEmptyString(str) - str is undefined", function () {
         expect(msngr.utils.isEmptyString(undefined)).to.equal(true);
+    });
+
+    it("msngr.utils.isEmptyString(str) - str is null", function () {
         expect(msngr.utils.isEmptyString(null)).to.equal(true);
+    });
+
+    it("msngr.utils.isEmptyString(str) - str is an object", function () {
         expect(msngr.utils.isEmptyString({})).to.equal(false);
+    });
+
+    it("msngr.utils.isEmptyString(str) - str is a number", function () {
         expect(msngr.utils.isEmptyString(7)).to.equal(false);
+    });
+
+    it("msngr.utils.isEmptyString(str) - str is an array", function () {
         expect(msngr.utils.isEmptyString([])).to.equal(false);
+    });
+
+    it("msngr.utils.isEmptyString(str) - str is a Date", function () {
         expect(msngr.utils.isEmptyString(new Date())).to.equal(false);
     });
+
+    // hasWildCard(str)
 
     it("msngr.utils.hasWildCard(str)", function () {
         expect(msngr.utils.hasWildCard("whatever")).to.equal(false);

--- a/src/utils/validation.cspec.js
+++ b/src/utils/validation.cspec.js
@@ -1,0 +1,24 @@
+if (typeof chai === "undefined" && typeof window === "undefined") {
+    var chai = require("chai");
+}
+
+if (typeof expect === "undefined") {
+    var expect = chai.expect;
+}
+
+if (typeof msngr === "undefined" && typeof window === "undefined") {
+    var msngr = require("../../msngr");
+}
+
+describe("./utils/validation.js", function () {
+    "use strict";
+
+    it("msngr.utils.getType(obj) - obj is a HTMLDivElement", function () {
+        expect(msngr.utils.getType(document.createElement("div"))).to.equal("[object HTMLDivElement]");
+    });
+
+    it("msngr.utils.getType(obj) - obj is a HTMLInputElement", function () {
+        expect(msngr.utils.getType(document.createElement("input"))).to.equal("[object HTMLInputElement]");
+    });
+
+});

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -4,6 +4,9 @@ msngr.extend((function () {
 	return {
 		utils: {
 			getType: function (obj) {
+				if (!msngr.utils.exists(obj)) {
+					return "" + obj;
+				}
 				return Object.prototype.toString.call(obj);
 			},
 			isNullOrUndefined: function (obj) {

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -13,28 +13,28 @@ msngr.extend((function () {
 				return (obj === undefined || obj === null);
 			},
 			exists: function (obj) {
-				return !this.isNullOrUndefined(obj);
+				return !msngr.utils.isNullOrUndefined(obj);
 			},
 			isString: function (str) {
-	            return (this.getType(str) === "[object String]");
+	            return (msngr.utils.getType(str) === "[object String]");
 	        },
 	        isDate: function (obj) {
-	            return (this.getType(obj) === "[object Date]");
+	            return (msngr.utils.getType(obj) === "[object Date]");
 	        },
 	        isArray: function (obj) {
-	            return (this.getType(obj) === "[object Array]");
+	            return (msngr.utils.getType(obj) === "[object Array]");
 	        },
 	        isNumber: function (obj) {
-	            return (this.getType(obj) === "[object Number]");
+	            return (msngr.utils.getType(obj) === "[object Number]");
 	        },
 	        isObject: function (obj) {
-	            return (this.getType(obj) === "[object Object]");
+	            return (msngr.utils.getType(obj) === "[object Object]");
 	        },
 	        isFunction: function (func) {
-	            return (this.getType(func) === "[object Function]");
+	            return (msngr.utils.getType(func) === "[object Function]");
 	        },
 	        isEmptyString: function (str) {
-	            var isStr = this.isString(str);
+	            var isStr = msngr.utils.isString(str);
 	            if (str === undefined || str === null || (isStr && str.toString().trim().length === 0)) {
 	                return true;
 	            }


### PR DESCRIPTION
Unit test explosion pulls multiple tests out of each unit test method and puts them in their own method. While this artificially inflates the number of unit tests it also provides a better way of tracking what is covered and how and makes it easier to add new ones. This also adds several new unit tests.

This is part one that covers all of the utility and main methods. Covering the memory, binder and messenger are going to take more time and won't be finished until other API modifications are done.